### PR TITLE
Return type LocalVolumeSource instead of HostPathVolumeSource

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,3 +38,17 @@ k apply -f example/pvc.yaml
 ```
 
 - start using the pvc in different pod scenarios, see example pod-*.yaml
+
+## NOTICE on block mount tests in minikube
+The busybox implementation of losetup lacks some flags on which the kubernetes currently depends on.
+(see https://github.com/kubernetes/kubernetes/issues/83265 )
+
+So for block mounts on minikube you have to copy a "full" linux losetup binary to minikube  
+
+If you're on linux e.g.:
+
+```
+ minikube ssh 'sudo rm /sbin/losetup'
+ scp -o 'StrictHostKeyChecking=no' -i $(minikube ssh-key) $(which losetup)  docker@$(minikube ip):/tmp/losetup
+ minikube ssh 'sudo mv /tmp/losetup /sbin/losetup'
+```

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -44,7 +44,7 @@ type lvmProvisioner struct {
 	pullPolicy     v1.PullPolicy
 }
 
-// NewLVMProvisioner creates a new hostpath provisioner
+// NewLVMProvisioner creates a new lvm provisioner
 func NewLVMProvisioner(kubeClient clientset.Interface, namespace, lvDir, devicePattern, provisionerImage, defaultLVMType, pullPolicy string) controller.Provisioner {
 	pp := v1.PullAlways
 	if strings.ToLower(pullPolicy) == pullIfNotPresent {
@@ -150,7 +150,7 @@ func (p *lvmProvisioner) Provision(options controller.ProvisionOptions) (*v1.Per
 				v1.ResourceName(v1.ResourceStorage): options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)],
 			},
 			PersistentVolumeSource: v1.PersistentVolumeSource{
-				HostPath: &v1.HostPathVolumeSource{
+				Local: &v1.LocalVolumeSource{
 					Path: path,
 				},
 			},
@@ -355,11 +355,11 @@ func (p *lvmProvisioner) createProvisionerPod(va volumeAction) (err error) {
 }
 
 func (p *lvmProvisioner) getPathAndNodeForPV(pv *v1.PersistentVolume) (path, node string, err error) {
-	hostPath := pv.Spec.PersistentVolumeSource.HostPath
-	if hostPath == nil {
-		return "", "", fmt.Errorf("no HostPath set")
+	localPvc := pv.Spec.PersistentVolumeSource.Local
+	if localPvc == nil {
+		return "", "", fmt.Errorf("no local PVC set")
 	}
-	path = hostPath.Path
+	path = localPvc.Path
 
 	nodeAffinity := pv.Spec.NodeAffinity
 	if nodeAffinity == nil {

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -157,9 +157,7 @@ func startDaemon(c *cli.Context) error {
 	}
 
 	provisioner := NewLVMProvisioner(kubeClient, namespace, mountPoint, devicePattern, provisionerImage, defaultLVMType, pullPolicy)
-	if err != nil {
-		return err
-	}
+
 	pc := pvController.NewProvisionController(
 		kubeClient,
 		provisionerName,

--- a/deploy/start-minikube-on-linux.sh
+++ b/deploy/start-minikube-on-linux.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/bash
+
+minikube start --memory 5g
+minikube ssh 'for i in 0 1; do fallocate -l 1G loop${i} ; sudo losetup -f loop${i}; sudo losetup -a ; done'
+minikube ssh 'sudo rm /sbin/losetup'
+scp -o 'StrictHostKeyChecking=no' -i $(minikube ssh-key) $(which losetup)  docker@$(minikube ip):/tmp/losetup
+minikube ssh 'sudo mv /tmp/losetup /sbin/losetup'


### PR DESCRIPTION

* return a PersistentVolume of type LocalVolumeSource instead of type HostPathVolumeSource
https://pkg.go.dev/k8s.io/api/core/v1?tab=doc#LocalVolumeSource

* adding a hint on how to work around a losetup issue with minikube (see https://github.com/kubernetes/kubernetes/issues/83265 )

Fixes #3 
