### PR TITLE
first integration test version

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine
+
+ENV KUBECONFIG /files/.kubeconfig
+
+RUN apk add --update ca-certificates \
+ && apk add --update -t deps curl bats \
+ && curl -L https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl  -o /usr/local/bin/kubectl \
+ && chmod +x /usr/local/bin/kubectl
+
+COPY bats /bats
+COPY files /files
+

--- a/tests/bats/test.bats
+++ b/tests/bats/test.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats 
+
+@test "deploy csi-lvm-controller" {
+    run kubectl apply -f /files/controller.yaml
+    [ "$status" -eq 0 ]
+}
+
+@test "csi-lvm-controller running" {
+    run sleep 2 && kubectl get pods -n csi-lvm
+    [ "$status" -eq 0 ]
+    [ $(expr "$output" : "csi-lvm-controller.*Running") ]
+}
+
+@test "deploy linear pod" {
+    run kubectl apply -f /files/linear.yaml
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "persistentvolumeclaim/lvm-pvc-linear created" ]
+    [ "${lines[1]}" = "pod/volume-test created" ]
+} 
+
+@test "deploy block pod" {
+    run kubectl apply -f /files/block.yaml
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "persistentvolumeclaim/lvm-pvc-block created" ]
+    [ "${lines[1]}" = "pod/volume-test-block created" ]
+} 
+
+@test "linear pvc bound" {
+    run sleep 20 
+    run kubectl get pvc lvm-pvc-linear -o jsonpath="{.metadata.name},{.status.phase}" 
+    [ "$status" -eq 0 ]
+    [ "$output" = "lvm-pvc-linear,Bound" ]
+} 
+
+@test "linear pod running" {
+    run sleep 20 
+    run kubectl get pods volume-test -o jsonpath="{.metadata.name},{.status.phase}"
+    [ "$status" -eq 0 ]
+    [ "$output" = "volume-test,Running" ]
+}
+
+@test "block pvc bound" {
+    run kubectl get pvc lvm-pvc-block -o jsonpath="{.metadata.name},{.status.phase}"
+    [ "$status" -eq 0 ]
+    [ "$output" = "lvm-pvc-block,Bound" ]
+} 
+
+@test "block pod running" {
+    run kubectl get pods volume-test-block -o jsonpath="{.metadata.name},{.status.phase}"
+    [ "$status" -eq 0 ]
+    [ "$output" = "volume-test-block,Running" ]
+}
+
+@test "delete linear pod" {
+    run kubectl delete -f /files/linear.yaml
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "persistentvolumeclaim \"lvm-pvc-linear\" deleted" ]
+    [ "${lines[1]}" = "pod \"volume-test\" deleted" ]
+} 
+
+@test "delete block pod" {
+    run kubectl delete -f /files/block.yaml
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "persistentvolumeclaim \"lvm-pvc-block\" deleted" ]
+    [ "${lines[1]}" = "pod \"volume-test-block\" deleted" ]
+} 
+
+@test "linear pvc deleted" {
+    run sleep 5
+    run kubectl get pvc lvm-pvc-linear -o jsonpath="{.metadata.name},{.status.phase}" 
+    [ "$status" -ne 0 ]
+} 
+
+@test "block pvc deleted" {
+    run kubectl get pvc lvm-pvc-block -o jsonpath="{.metadata.name},{.status.phase}"
+    [ "$status" -ne 0 ]
+} 

--- a/tests/files/block.yaml
+++ b/tests/files/block.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lvm-pvc-block
+  namespace: default
+  annotations:
+    csi-lvm.metal-stack.io/type: "linear"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  storageClassName: csi-lvm
+  resources:
+    requests:
+      storage: 10Mi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: volume-test-block
+  namespace: default
+spec:
+  containers:
+  - name: volume-test-block
+    image: nginx:stable-alpine
+    imagePullPolicy: IfNotPresent
+    ports:
+    - containerPort: 80
+    volumeDevices:
+      - name: block
+        devicePath: /dev/xvda
+    resources:
+      limits:
+        cpu: 100m
+        memory: 100M
+  volumes:
+  - name: block
+    persistentVolumeClaim:
+      claimName: lvm-pvc-block

--- a/tests/files/controller.yaml
+++ b/tests/files/controller.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: csi-lvm
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-lvm
+provisioner: metal-stack.io/csi-lvm
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-lvm-controller
+  namespace: csi-lvm
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-lvm-controller
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "persistentvolumeclaims"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["endpoints", "persistentvolumes", "pods"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-lvm-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-lvm-controller
+subjects:
+- kind: ServiceAccount
+  name: csi-lvm-controller
+  namespace: csi-lvm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: csi-lvm-controller
+  namespace: csi-lvm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-lvm-controller
+  template:
+    metadata:
+      labels:
+        app: csi-lvm-controller
+    spec:
+      serviceAccountName: csi-lvm-controller
+      containers:
+      - name: csi-lvm-controller
+        image: metalstack/csi-lvm-controller
+        imagePullPolicy: IfNotPresent
+        command:
+        - /csi-lvm-controller
+        args:
+        - start
+        env:
+        - name: CSI_LVM_PROVISIONER_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CSI_LVM_PULL_POLICY
+          value: "ifnotpresent"
+        - name: CSI_LVM_PROVISIONER_IMAGE
+          value: "metalstack/csi-lvm-provisioner"
+        - name: CSI_LVM_DEVICE_PATTERN
+          # IMPORTANT: you cannot specify a wildcard (*) at any position in the devices grok.
+          # value: "/dev/nvme[0-9]n[0-9]"
+          # value: "/dev/sd[abcd]"
+          value: "/dev/loop[0-1]"

--- a/tests/files/linear.yaml
+++ b/tests/files/linear.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lvm-pvc-linear
+  namespace: default
+  annotations:
+    csi-lvm.metal-stack.io/type: "linear"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: csi-lvm
+  resources:
+    requests:
+      storage: 10Mi
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: volume-test
+  namespace: default
+spec:
+  containers:
+  - name: volume-test
+    image: nginx:stable-alpine
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+    - name: linear
+      mountPath: /linear
+
+    ports:
+    - containerPort: 80
+    resources:
+      limits:
+        cpu: 100m
+        memory: 100M
+  volumes:
+  - name: linear
+    persistentVolumeClaim:
+      claimName: lvm-pvc-linear


### PR DESCRIPTION
This PR implements a first integration test first (#12)
```
$ make tests
Starting minikube testing setup ... please wait ...
1..12
ok 1 deploy csi-lvm-controller
ok 2 csi-lvm-controller running
ok 3 deploy linear pod
ok 4 deploy block pod
ok 5 linear pvc bound
ok 6 linear pod running
ok 7 block pvc bound
ok 8 block pod running
ok 9 delete linear pod
ok 10 delete block pod
ok 11 linear pvc deleted
ok 12 block pvc deleted
🔥  Deleting "minikube" in kvm2 ...
💀  Removed all traces of the "minikube" cluster.
```