### PR TITLE
Introduce new daemonset csi-lvm-reviver to survive reboots

### DIFF
--- a/cmd/provisioner/main.go
+++ b/cmd/provisioner/main.go
@@ -32,6 +32,7 @@ func main() {
 	p.Commands = []*cli.Command{
 		createLVCmd(),
 		deleteLVCmd(),
+		reviveLVsCmd(),
 	}
 	p.CommandNotFound = cmdNotFound
 	p.OnUsageError = onUsageError

--- a/cmd/provisioner/revivelvs.go
+++ b/cmd/provisioner/revivelvs.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+
+	"github.com/google/lvmd/commands"
+	"github.com/urfave/cli/v2"
+	"k8s.io/klog"
+)
+
+var (
+	envDirectory = "CSI_LVM_MOUNTPOINT"
+)
+
+func reviveLVsCmd() *cli.Command {
+	return &cli.Command{
+		Name: "revivelvs",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  flagVGName,
+				Usage: "Required. the name of the volumegroup",
+				Value: "csi-lvm",
+			},
+			&cli.StringFlag{
+				Name:    flagDirectory,
+				Usage:   "Required. the name of the directory to mount the lv",
+				EnvVars: []string{envDirectory},
+				Value:   "/tmp/csi-lvm",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			if err := reviveLVs(c); err != nil {
+				klog.Fatalf("Error reviving logical volumes: %v", err)
+				return err
+			}
+			// stay alive
+			for {
+				time.Sleep(time.Hour)
+			}
+		},
+	}
+}
+
+// reviveLVs scans for existing volumes which are not mounted correctly
+func reviveLVs(c *cli.Context) error {
+	klog.Infof("starting reviver: %s", c)
+	vgName := c.String(flagVGName)
+	if vgName == "" {
+		return fmt.Errorf("invalid empty flag %v", flagVGName)
+	}
+	dirName := c.String(flagDirectory)
+	if dirName == "" {
+		return fmt.Errorf("invalid empty flag %v", flagDirectory)
+	}
+	vgexists := vgExists(vgName)
+	if !vgexists {
+		klog.Infof("volumegroup: %s not found\n", vgName)
+		vgactivate(vgName)
+		// now check again for existing vg again
+		vgexists = vgExists(vgName)
+		if !vgexists {
+			klog.Infof("volumegroup: %s not found\n", vgName)
+			return nil
+		}
+	}
+	cmd := exec.Command("lvchange", "-ay", vgName)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.Infof("unable to activate logical volumes:%s %v", out, err)
+	}
+	lvs, err := commands.ListLV(context.Background(), vgName)
+	if err != nil {
+		klog.Infof("unable to list existing logicalvolumes:%v", err)
+	}
+	for _, lv := range lvs {
+		klog.Infof("inspect lv:%s\n", lv.Name)
+		targetPath := dirName + "/" + lv.Name
+		tp, err := os.Lstat(targetPath)
+		if err != nil {
+			klog.Infof("target %s is missing. Reviving ...\n", targetPath)
+			for _, n := range lv.Tags {
+				if n == "isBlock=true" {
+					bindMountLV(lv.Name, vgName, dirName)
+				} else if n == "isBlock=false" {
+					mountLV(lv.Name, vgName, dirName)
+				}
+			}
+		} else {
+			// Check already existing volumes for missing isBlock tags and add tag if missing
+			// This is only needed for migrating from previous csi-lvm versions.
+			// This must only run once for every volume created with lvm-csi v0.4.x
+			// This else block can be removed later.
+			klog.Infof("target %s exists. Checking for missing isBlock tags ...\n", targetPath)
+			blockTagFound := false
+			for _, n := range lv.Tags {
+				if n == "isBlock=true" || n == "isBlock=false" {
+					blockTagFound = true
+				}
+			}
+			if !blockTagFound {
+				blockMode := true
+				if tp.Mode().IsDir() {
+					blockMode = false
+				}
+				klog.Infof("volume %s lacks isBlock tags. Readding isBlock=%t\n", targetPath, blockMode)
+				commands.AddTagLV(context.Background(), vgName, lv.Name, []string{"lv.metal-stack.io/csi-lvm", "isBlock=" + strconv.FormatBool(blockMode)})
+			}
+		}
+	}
+	return nil
+}

--- a/deploy/controller.yaml
+++ b/deploy/controller.yaml
@@ -66,7 +66,7 @@ spec:
       serviceAccountName: csi-lvm-controller
       containers:
       - name: csi-lvm-controller
-        image: metalstack/csi-lvm-controller:v0.4.1
+        image: metalstack/csi-lvm-controller:v0.5.0
         imagePullPolicy: IfNotPresent
         command:
         - /csi-lvm-controller
@@ -80,7 +80,7 @@ spec:
         - name: CSI_LVM_PULL_POLICY
           value: "ifnotpresent"
         - name: CSI_LVM_PROVISIONER_IMAGE
-          value: "metalstack/csi-lvm-provisioner:v0.4.1"
+          value: "metalstack/csi-lvm-provisioner:v0.5.0"
         - name: CSI_LVM_DEVICE_PATTERN
           # IMPORTANT: you cannot specify a wildcard (*) at any position in the devices grok.
           # value: "/dev/nvme[0-9]n[0-9]"

--- a/deploy/reviver.yaml
+++ b/deploy/reviver.yaml
@@ -1,0 +1,137 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: csi-lvm
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-lvm-reviver
+  namespace: csi-lvm
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: csi-lvm-reviver-psp
+  namespace: csi-lvm
+spec:
+  allowPrivilegeEscalation: true
+  privileged: true
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: csi-lvm-reviver-psp
+  namespace: csi-lvm
+rules:
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - csi-lvm-reviver-psp
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: csi-lvm-reviver
+  namespace: csi-lvm
+rules:
+- apiGroups: [""]
+  resources: ["persistentvolumes"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: csi-lvm-reviver-psp
+  namespace: csi-lvm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: csi-lvm-reviver-psp
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: csi-lvm-reviver
+  namespace: csi-lvm
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: csi-lvm-reviver
+  namespace: csi-lvm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: csi-lvm-reviver
+subjects:
+- kind: ServiceAccount
+  name: csi-lvm-reviver
+  namespace: csi-lvm
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: csi-lvm-reviver
+  namespace: csi-lvm
+spec:
+  selector:
+    matchLabels:
+      app: csi-lvm-reviver
+  template:
+    metadata:
+      labels:
+        app: csi-lvm-reviver
+    spec:
+      serviceAccountName: csi-lvm-reviver
+      containers:
+      - name: csi-lvm-reviver
+        image: metalstack/csi-lvm-provisioner:v0.5.0
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        env:
+          - name: CSI_LVM_MOUNTPOINT
+            value: "/tmp/csi-lvm"
+        command:
+        - /csi-lvm-provisioner
+        args:
+        - revivelvs
+        volumeMounts:
+          - mountPath: /tmp/csi-lvm
+            name: data
+            mountPropagation: Bidirectional
+          - mountPath: /dev
+            name: devices
+          - mountPath: /lib/modules
+            name: modules
+      volumes:
+        - hostPath:
+            path: /tmp/csi-lvm
+            type: DirectoryOrCreate
+          name: data
+        - hostPath:
+            path: /dev
+            type: DirectoryOrCreate
+          name: devices
+        - hostPath:
+            path: /lib/modules
+            type: DirectoryOrCreate
+          name: modules


### PR DESCRIPTION
To re-activate and re-create persistent volumes after a reboot, a daemonset is needed, that gets started on every node.

The csi-lvm-reviver pod on every node checks at the start for existing but unmounted logical volumes and recreates the mount in /tmp/csi-lvm.
After it's done it goes into an indefinite wait loop to stay alive.

For migrating from previous csi-lvm versions it currently also scans for existing and mounted volumes and adds appropriate "isBlock" tags, which are needed to recreate the mounts after a reboot. This part can be deleted later.

Resolves: #2 