### PR TITLE
add /run/lock/lvm directory to pods

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -282,6 +282,12 @@ func (p *lvmProvisioner) createProvisionerPod(va volumeAction) (err error) {
 							MountPath:        "/etc/lvm/cache",
 							MountPropagation: &mountPropagation,
 						},
+						{
+							Name:             "lvmlock",
+							ReadOnly:         false,
+							MountPath:        "/run/lock/lvm",
+							MountPropagation: &mountPropagation,
+						},
 					},
 					ImagePullPolicy: p.pullPolicy,
 					SecurityContext: &v1.SecurityContext{
@@ -341,6 +347,15 @@ func (p *lvmProvisioner) createProvisionerPod(va volumeAction) (err error) {
 					VolumeSource: v1.VolumeSource{
 						HostPath: &v1.HostPathVolumeSource{
 							Path: "/etc/lvm/cache",
+							Type: &hostPathType,
+						},
+					},
+				},
+				{
+					Name: "lvmlock",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{
+							Path: "/run/lock/lvm",
 							Type: &hostPathType,
 						},
 					},

--- a/deploy/reviver.yaml
+++ b/deploy/reviver.yaml
@@ -128,6 +128,9 @@ spec:
           - mountPath: /etc/lvm/cache
             name: lvmcache
             mountPropagation: Bidirectional
+          - mountPath: /run/lock/lvm
+            name: lvmlock
+            mountPropagation: Bidirectional
       volumes:
         - hostPath:
             path: /tmp/csi-lvm
@@ -149,3 +152,7 @@ spec:
             path: /etc/lvm/cache
             type: DirectoryOrCreate
           name: lvmcache
+        - hostPath:
+            path: /run/lock/lvm
+            type: DirectoryOrCreate
+          name: lvmlock

--- a/tests/files/reviver.yaml
+++ b/tests/files/reviver.yaml
@@ -117,6 +117,15 @@ spec:
             name: devices
           - mountPath: /lib/modules
             name: modules
+          - mountPath: /etc/lvm/backup
+            name: lvmbackup
+            mountPropagation: Bidirectional
+          - mountPath: /etc/lvm/cache
+            name: lvmcache
+            mountPropagation: Bidirectional
+          - mountPath: /run/lock/lvm
+            name: lvmlock
+            mountPropagation: Bidirectional
       volumes:
         - hostPath:
             path: /tmp/csi-lvm
@@ -130,3 +139,15 @@ spec:
             path: /lib/modules
             type: DirectoryOrCreate
           name: modules
+        - hostPath:
+            path: /etc/lvm/backup
+            type: DirectoryOrCreate
+          name: lvmbackup
+        - hostPath:
+            path: /etc/lvm/cache
+            type: DirectoryOrCreate
+          name: lvmcache
+        - hostPath:
+            path: /run/lock/lvm
+            type: DirectoryOrCreate
+          name: lvmlock


### PR DESCRIPTION
add /run/lock/lvm to provisioner and reviver pods:

from /etc/lvm/lvm.conf:
```
        # Directory to use for LVM command file locks.
        # Local non-LV directory that holds file-based locks while commands are
        # in progress. 
        locking_dir = "/run/lock/lvm"
```