### PR TITLE
increase timeout for provisioner pods

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -381,7 +381,7 @@ func (p *lvmProvisioner) createProvisionerPod(va volumeAction) (err error) {
 	}()
 
 	completed := false
-	retrySeconds := 20
+	retrySeconds := 60
 	for i := 0; i < retrySeconds; i++ {
 		pod, err := p.kubeClient.CoreV1().Pods(p.namespace).Get(provisionerPod.Name, metav1.GetOptions{})
 		if err != nil {

--- a/deploy/start-minikube-on-linux.sh
+++ b/deploy/start-minikube-on-linux.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-minikube start --memory 5g
+minikube start --memory 5g --driver kvm2
 minikube ssh 'for i in 0 1; do fallocate -l 1G loop${i} ; sudo losetup -f loop${i}; sudo losetup -a ; done'
 minikube ssh 'sudo rm /sbin/losetup'
 scp -o 'StrictHostKeyChecking=no' -i $(minikube ssh-key) $(which losetup)  docker@$(minikube ip):/tmp/losetup


### PR DESCRIPTION
increase timeout for provisioner pods to 60s

mkfs on large filesystems can take longer than 20s (see #32), but I've seen sometimes timeouts on smaller filesystems, too when scheduler takes longer to actually start the provisioner pod